### PR TITLE
Fix custom paintbox not applying

### DIFF
--- a/lib/text_recognizer_painter.dart
+++ b/lib/text_recognizer_painter.dart
@@ -93,10 +93,10 @@ class TextRecognizerPainter extends CustomPainter {
         size,
         absoluteImageSize);
 
-    final Paint paintbox = paintboxCustom ?? Paint()
+    final Paint paintbox = paintboxCustom ?? (Paint()
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2.0
-      ..color = const Color.fromARGB(153, 102, 160, 241);
+      ..color = const Color.fromARGB(153, 102, 160, 241));
     canvas.drawRect(
       Rect.fromLTRB(boxLeft, boxTop, boxRight, boxBottom),
       paintbox,


### PR DESCRIPTION
I was playing around with the library and found out that custom paintboxes don't work, at least colors. I went to check the code of the library:

https://github.com/vbalagovic/flutter_scalable_ocr/blob/287500d1ba94111c0c9175dea09213d656209d83/lib/text_recognizer_painter.dart#L96-L99

This makes the provided `paintboxCustom` redundant, as values get overidden, due to execution order.
Adding `(` around Paint() and at the end makes it work.